### PR TITLE
Possibly simplify array from permutations code

### DIFF
--- a/src/leetcode/array_from_permutations.rs
+++ b/src/leetcode/array_from_permutations.rs
@@ -1,9 +1,8 @@
 pub fn build_array(numbers: Vec<i32>) -> Vec<i32> {
-    let mut res = Vec::with_capacity(numbers.len());
-    for &number in numbers.iter() {
-        res.push(numbers[number as usize]);
-    }
-    res
+    numbers
+        .iter()
+        .map(|&number| numbers[number as usize])
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There is no change in behavior. Imo with this change it is more readable / simple. What do you think? There could be a performance different because `with_capacity` is not used, but based on [the docs](https://doc.rust-lang.org/std/vec/struct.Vec.html#impl-FromIterator%3CT%3E-for-Vec%3CT%3E) it says that `Vec` may "preallocate based on [Iterator::size_hint()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.size_hint)", so there may not be a performance decrease.
